### PR TITLE
Update software.md URLs

### DIFF
--- a/Subnautica/settingup/software.md
+++ b/Subnautica/settingup/software.md
@@ -30,14 +30,14 @@ Here's a simple checklist of the tools that I've used in this tutorial and where
 | Tool Name                | Where to download                                            |
 | ------------------------ | ------------------------------------------------------------ |
 | Visual Studio            | [Microsoft.com](https://visualstudio.microsoft.com/vs/community/) |
-| dnSpy                    | [Github.com](https://github.com/dnSpy/dnSpy/releases)        |
+| dnSpy                    | [Github.com](https://github.com/dnSpy/dnSpy/releases/latest) |
 | QModManager              | [Nexusmods.com](https://www.nexusmods.com/subnautica/mods/201?tab=files) |
 | SML Helper               | [Nexusmods.com](https://www.nexusmods.com/subnautica/mods/113?tab=files) |
 | QModManager (Below Zero) | [Nexusmods.com](https://www.nexusmods.com/subnauticabelowzero/mods/1?tab=files) |
 | SML Helper (Below Zero)  | [Nexusmods.com](https://www.nexusmods.com/subnauticabelowzero/mods/34?tab=files) |
-| BepInEx-Publicizer       | [Github.com](https://github.com/MrPurple6411/Bepinex-Tools/releases/tag/1.0.0-Publicizer) |
+| BepInEx-Publicizer       | [Github.com](https://github.com/MrPurple6411/Bepinex-Tools/releases/latest) |
 | Vortex                   | [Nexusmods.com](https://www.nexusmods.com/site/mods/1?tab=files) |
-| GitHub Desktop           | [Github.com](https://desktop.github.com/)                    |
+| GitHub Desktop           | [Github.com](https://desktop.github.com/) |
 
 Something to be very aware of is that development of these tools is pretty active and things tend to change quite frequently. It's really, really important to avail yourself of the latest versions and double check compatibility and support between various tools and game versions.
 


### PR DESCRIPTION
Updated the GitHub URLs to always point to the latest release of dnSpy and BepInEx-Publicizer rather than specific tags.  It doesn't matter much for dnSpy since it is archived, but the old URL for BepInEx-Publicizer pointed to an outdated version that did not work for me.